### PR TITLE
Basic error recovery

### DIFF
--- a/achille-pandoc/Achille/Pandoc.hs
+++ b/achille-pandoc/Achille/Pandoc.hs
@@ -55,11 +55,11 @@ readPandocMetaWith ropts src = apply (R.readPandocMetaWith ropts) src
 -- Some recipes to render pandoc documents to HTML.
 
 -- | Convert pandoc document to text, using default writer options.
-renderPandoc :: MonadFail m => Task m Pandoc -> Task m Text
+renderPandoc :: (AchilleIO m, MonadFail m) => Task m Pandoc -> Task m Text
 renderPandoc = renderPandocWith def
 
 -- | Convert pandoc document to text, using provided writer options.
-renderPandocWith :: MonadFail m => WriterOptions -> Task m Pandoc -> Task m Text
+renderPandocWith :: (AchilleIO m, MonadFail m) => WriterOptions -> Task m Pandoc -> Task m Text
 renderPandocWith wopts = apply (R.renderPandocWith wopts)
 
 

--- a/achille-pandoc/Achille/Pandoc/Recipe.hs
+++ b/achille-pandoc/Achille/Pandoc/Recipe.hs
@@ -44,20 +44,20 @@ readPandocWith
   :: (MonadFail m, AchilleIO m)
   => ReaderOptions -> Recipe m Path Pandoc
 readPandocWith ropts = id &&& readText >>>
-  recipe "readPandoc" \cache v -> do
+  recipe "readPandoc" \v -> do
     let (vsrc, vtxt) = splitValue v
     let ext = takeExtension $ theVal vsrc
     reader <- getReader ext
     case runPure (reader ropts $ theVal vtxt) of
       Left err  -> fail $ unpack $ renderError err
-      Right doc -> pure (value (hasChanged vtxt) doc, cache)
+      Right doc -> pure (value (hasChanged vtxt) doc)
 
 -- | Read a pandoc document and its frontmatter metadata from path, using provided reader options.
 readPandocMetaWith
   :: (MonadFail m, AchilleIO m, FromJSON a)
   => ReaderOptions -> Recipe m Path (a, Pandoc)
 readPandocMetaWith ropts = id &&& readByteString >>>
-  recipe "readPandocMeta" \cache v -> do
+  recipe "readPandocMeta" \v -> do
     let (vsrc, vbs) = splitValue v
         ext = takeExtension $ theVal vsrc
     reader <- getReader ext
@@ -65,14 +65,14 @@ readPandocMetaWith ropts = id &&& readByteString >>>
       Done rest meta ->
         case runPure (reader ropts $ decodeUtf8 rest) of
           Left err -> fail $ show (theVal vsrc) <> ": " <> unpack (renderError err)
-          Right doc -> pure (value (hasChanged v) (meta, doc), cache)
+          Right doc -> pure (value (hasChanged v) (meta, doc))
       -- TODO(flupe): better error-reporting
       -- TODO(flupe): cache front-matter?
       _ -> fail $ show (theVal vsrc) <> ": Could not parse YAML frontmatter"
 
 -- | Convert pandoc document to text, using provided writer options.
-renderPandocWith :: MonadFail m => WriterOptions -> Recipe m Pandoc Text
-renderPandocWith wopts = recipe "renderPandoc" \cache vdoc -> do
+renderPandocWith :: (AchilleIO m, MonadFail m) => WriterOptions -> Recipe m Pandoc Text
+renderPandocWith wopts = recipe "renderPandoc" \vdoc -> do
   case runPure (writeHtml5String wopts $ theVal vdoc) of
     Left err   -> fail $ unpack $ renderError err
-    Right html -> pure (value (hasChanged vdoc) html, cache)
+    Right html -> pure (value (hasChanged vdoc) html)

--- a/achille-pandoc/Achille/Pandoc/Recipe.hs
+++ b/achille-pandoc/Achille/Pandoc/Recipe.hs
@@ -24,7 +24,7 @@ import Achille.Diffable
 import Achille.IO
 import Achille.Path
 import Achille.Recipe
-import Achille.Result
+import Achille.Task.Prim
 
 -- TODO(flupe): caching/hashing of pandoc options
 

--- a/achille-stache/Achille/Stache.hs
+++ b/achille-stache/Achille/Stache.hs
@@ -32,6 +32,6 @@ loadTemplates = apply R.loadTemplates
 
 -- | Apply a Mustache template to a value.
 applyTemplate
-  :: (Applicative m, ToJSON a)
+  :: (Monad m, ToJSON a)
   => Task m Template -> Task m a -> Task m Text
 applyTemplate t x = apply R.applyTemplate (t :*: x)

--- a/achille-stache/Achille/Stache/Recipe.hs
+++ b/achille-stache/Achille/Stache/Recipe.hs
@@ -44,19 +44,20 @@ unlessM b x = b >>= \b -> unless b x
 
 -- TODO(flupe): recursively fetch (and cache) partials?
 loadTemplate :: Recipe IO Path Template
-loadTemplate = recipe "loadTemplate" \cache vsrc -> do
+loadTemplate = recipe "loadTemplate" \vsrc -> do
   Context{..} <- getContext
   let Config{..} = siteConfig
   let path = contentDir </> theVal vsrc
   unlessM (doesFileExist path) $ fail ("Could not find template file " <> show path)
   mtime <- getModificationTime path
   setDeps (dependsOnFile path)
-  case fromCache cache of
+  fromCache <$> getCache >>= \case
     Just (t :: Template) | mtime <= lastTime, not (hasChanged vsrc) ->
-      pure (value False t, cache)
+      pure (value False t)
     mc -> do
       t <- lift $ compileMustacheFile (toFilePath path) -- TODO(flupe): handle parser exception gracefully
-      pure (value (Just t /= mc) t, toCache t)
+      putCache (toCache t)
+      pure (value (Just t /= mc) t)
 
 tToNode :: Template -> [Node]
 tToNode t = templateCache t Map.! templateActual t
@@ -65,11 +66,11 @@ tToNode t = templateCache t Map.! templateActual t
 
 -- | Load all templates from the input directory.
 loadTemplates :: Recipe IO Path (Map PName Template)
-loadTemplates = recipe "loadTemplates" \cache vdir -> do
+loadTemplates = recipe "loadTemplates" \vdir -> do
   Context{..} <- getContext
   let Config{..} = siteConfig
   let dir = contentDir </> theVal vdir
-  let stored :: Map PName Template = fromMaybe Map.empty (fromCache cache)
+  stored :: Map PName Template <- fromMaybe Map.empty . fromCache <$> getCache
   unlessM (doesDirExist dir) $ fail ("Could not find directory " <> show dir)
   files <- fmap (dir </>) . filter ((== ".mustache") . takeExtension) <$> listDir dir
   templates :: [Value Template] <- forM files \src -> do
@@ -85,7 +86,8 @@ loadTemplates = recipe "loadTemplates" \cache vdir -> do
     tps' = tToNode . theVal <$> tps
     tps'' = (\(Value t c i) -> Value t { templateCache = tps' } c i) <$> tps
   setDeps (dependsOnFiles files)
-  pure (joinValue tps'', toCache (theVal <$> tps))
+  putCache $ toCache (theVal <$> tps)
+  pure (joinValue tps'')
 
-applyTemplate :: (Applicative m, ToJSON a) => Recipe m (Template, a) Text
+applyTemplate :: (Monad m, ToJSON a) => Recipe m (Template, a) Text
 applyTemplate = arr \(t, x) -> renderMustache t (toJSON x)

--- a/achille.cabal
+++ b/achille.cabal
@@ -40,8 +40,8 @@ library
                  , Achille.IO
                  , Achille.Path
                  , Achille.Recipe
-                 , Achille.Result
                  , Achille.Task
+                 , Achille.Task.Prim
                  , Achille.Writable
   other-modules: Achille.Core.Recipe
                , Achille.Core.Program

--- a/achille.cabal
+++ b/achille.cabal
@@ -71,6 +71,7 @@ test-suite test
                , Test.Achille.FakeIO
                , Test.Achille.Match
                , Test.Achille.ReadWrite
+               , Test.Achille.Recovery
   build-depends: base                 >= 4.16    && < 4.18
                , binary               >= 0.8.9   && < 0.9
                , binary-instances     >= 1.0.3   && < 1.1

--- a/achille/Achille/CLI.hs
+++ b/achille/Achille/CLI.hs
@@ -34,7 +34,7 @@ import Achille.IO           qualified as AIO
 import Achille.Core.Task (toProgram)
 import Achille.Context (Context(..))
 import Achille.DynDeps
-import Achille.Result
+import Achille.Task.Prim
 import Achille.Core.Recipe
 
 

--- a/achille/Achille/CLI.hs
+++ b/achille/Achille/CLI.hs
@@ -34,7 +34,7 @@ import Achille.IO           qualified as AIO
 import Achille.Core.Task (toProgram)
 import Achille.Context (Context(..))
 import Achille.DynDeps
-import Achille.Result (Result)
+import Achille.Result
 import Achille.Core.Recipe
 
 
@@ -106,7 +106,7 @@ runAchille cfg@Config{..} force t = do
         }
 
   -- 4. run task in context using cache
-  (_, deps, cache') <- runTask t ctx cache
+  (_, cache', deps) <- runTask t ctx cache
 
   AIO.log "Reported dynamic dependencies: "
   AIO.log $ show deps

--- a/achille/Achille/Core/Program.hs
+++ b/achille/Achille/Core/Program.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 module Achille.Core.Program where
 
-import Prelude hiding ((.), id, seq, fail, (>>=), (>>), fst, snd)
+import Prelude hiding ((.), id, seq, (>>=), (>>), fst, snd)
 
 import Control.Applicative (Alternative, empty, liftA2)
 import Control.Arrow
@@ -17,7 +17,7 @@ import Data.IntMap.Strict (IntMap, (!?))
 import Data.IntSet (IntSet)
 import Data.List (sort)
 import Data.Map.Strict (Map)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, catMaybes)
 import Data.Monoid (All(..))
 import Data.String (IsString(fromString))
 import Data.Time (UTCTime)
@@ -89,7 +89,7 @@ instance Show (Program m a) where
 -- | Run a program given some context and incoming cache.
 runProgram
   :: (Monad m, MonadFail m, AchilleIO m)
-  => Program m a -> Cache -> Result m (Value a, Cache)
+  => Program m a -> PrimTask m (Value a)
 runProgram = runProgramIn emptyEnv
 {-# INLINE runProgram #-}
 
@@ -120,53 +120,64 @@ depsClean edits lastTime (getFileDeps -> fdeps) = getAll $ foldMap (All . isClea
 
 runProgramIn
   :: (Monad m, MonadFail m, AchilleIO m)
-  => Env -> Program m a -> Cache -> Result m (Value a, Cache)
-runProgramIn env t cache = case t of
+  => Env -> Program m a -> PrimTask m (Value a)
+runProgramIn env t = case t of
 
   Var k -> case lookupEnv env k of
-    Just v  -> pure (v, cache)
-    Nothing -> Prelude.fail $ "Variable " <> show k <> " out of scope. This is a bug, please report!"
+    Just v  -> pure v
+    Nothing -> fail $ "Variable " <> show k <> " out of scope. This is a bug, please report!"
 
   Seq x y -> do
-    let (cx, cy) = splitCache cache
-    (_,  cx) <- runProgramIn env x cx
-    (vy, cy) <- runProgramIn env y cy
-    pure (vy, joinCache cx cy)
+    (cx, cy) <- splitCache <$> getCache
+    (_,  cx) <- withCache cx $ runProgramIn env x
+    (vy, cy) <- withCache cy $ runProgramIn env y
+    putCache (joinCache cx cy)
+    forward vy
 
   Bind x f -> do
-    let (cx, cf) = splitCache cache
-    (vx, cx) <- runProgramIn env x cx
-    (vy, cf) <- runProgramIn (bindEnv env vx) f cf
-    pure (vy, joinCache cx cf)
+    (cx, cf) <- splitCache <$> getCache
+    (vx, cx) <- withCache cx $ runProgramIn env x
+    case vx of
+      Nothing -> putCache (joinCache cx cf) *> silentFail
+      Just vx -> do
+        (vy, cf) <- withCache cf $ runProgramIn (bindEnv env vx) f
+        putCache (joinCache cx cf)
+        forward vy
+    -- TODO(flupe): propagate failure to environment
+    --              to allow things that do not depend on the value to be evaluated
 
-  -- TODO(flupe): error-recovery and propagation
-  Fail s -> Prelude.fail s
+  Fail s -> fail s
   --
   -- TODO(flupe): does this have to be a primitive of Program? what about lists? maps? 
   --              this is almost identical to Seq
   -- TODO(flupe): parallelism
   Pair x y -> do
-    let (cx, cy) = splitCache cache
-    (a, cx) <- runProgramIn env x cx
-    (b, cy) <- runProgramIn env y cy
-    pure (joinValue (a, b), joinCache cx cy)
+    (cx, cy) <- splitCache <$> getCache
+    (a, cx) <- withCache cx $ runProgramIn env x
+    (b, cy) <- withCache cy $ runProgramIn env y
+    putCache (joinCache cx cy)
+    forward (joinValue <$> ((,) <$> a <*> b))
 
-  Val v -> pure (v, cache)
+  Val v -> pure v
 
   Apply r x -> do
-    let (cx, cr) = splitCache cache
-    (a, cx) <- runProgramIn env x cx
-    (b, cr) <- runRecipe r cr a
-    pure (b, joinCache cx cr)
+    (cx, cr) <- splitCache <$> getCache
+    (a, cx) <- withCache cx $ runProgramIn env x
+    case a of
+      Nothing -> putCache (joinCache cx cr) *> silentFail
+      Just a -> do
+        (b, cr) <- withCache cr $ runRecipe r a
+        putCache (joinCache cx cr)
+        forward b
 
   Match pat (t :: Program m b) vars -> do
     context@Context{..} :: Context <- ask
     let Config{..} = siteConfig
     let thepat = FP.normalise (toFilePath currentDir <> "/" <> Glob.decompile pat)
     let pat' = Glob.simplify $ Glob.compile thepat -- NOTE(flupe): Glob.simplify doesn't do anything?
-    let stored :: Map Path Cache = fromMaybe Map.empty (fromCache cache)
+    stored :: Map Path Cache <- fromMaybe Map.empty . fromCache <$> getCache
     paths <- sort . fmap (normalise . makeRelative contentDir) <$> AIO.glob contentDir pat'
-    res :: [(Value b, Cache)] <- forM paths \src -> do
+    res :: [(Maybe (Value b), Cache)] <- forM paths \src -> do
       mtime <- AIO.getModificationTime (contentDir </> src)
       let currentDir = takeDirectory src
       let fileCache = stored Map.!? src
@@ -174,22 +185,25 @@ runProgramIn env t cache = case t of
         Just (cache, (x, deps, _))
           | mtime <= lastTime
           , not (envChanged env vars)
-          , depsClean updatedFiles lastTime deps -> tell deps $> (value False x, cache)
+          , depsClean updatedFiles lastTime deps ->
+              tell deps
+              $> (Just (value False x), cache)
         mpast -> do
           let (oldVal, cache) = case mpast of
                 Just (_, (x, _, cache)) -> (Just x, cache)
                 Nothing                 -> (Nothing, emptyCache)
               env' = bindEnv env (value False src)
-          ((t, cache'), deps) <- listen $
-            local (\c -> c { currentDir = currentDir
-                           , updatedFiles = Map.insert (contentDir </> src) mtime updatedFiles
-                           })
-            $ runProgramIn env' t cache
-          pure ( value (Just (theVal t) == oldVal) (theVal t)
-               , toCache (theVal t, deps, cache')
-               )
+          --(t, cache') <-
+          local (\c -> c { currentDir = currentDir
+                         , updatedFiles = Map.insert (contentDir </> src) mtime updatedFiles
+                         })
+            $ withCache cache $ runProgramIn env' t
+          -- pure ( value (Just (theVal t) == oldVal) (theVal t)
+          --      , toCache (theVal t, deps, cache')
+          --      )
     let (values, caches) = unzip res
     tell (dependsOnPattern pat')
-    pure (joinValue values, toCache (Map.fromAscList (zip paths caches)))
+    putCache (toCache $ Map.fromAscList (zip paths caches))
+    pure (joinValue (catMaybes values))
 
 {-# INLINE runProgramIn #-}

--- a/achille/Achille/Core/Task.hs
+++ b/achille/Achille/Core/Task.hs
@@ -18,13 +18,10 @@ module Achille.Core.Task
 import Prelude hiding ((.), id, seq, fail, (>>=), (>>), fst, snd)
 
 import Control.Category
-import Control.Monad (forM)
-import Control.Monad.Reader.Class
+import Control.Monad.Reader.Class (reader)
 import Control.Applicative (Alternative, empty, liftA2)
 import Control.Arrow
-
 import Data.Binary (Binary)
-import Data.Functor ((<&>))
 import Data.IntMap.Strict (IntMap, (!?))
 import Data.IntSet (IntSet)
 import Data.List (sort)
@@ -32,28 +29,23 @@ import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
 import Data.String (IsString(fromString))
 import Data.Time (UTCTime)
-
 import System.FilePath.Glob (Pattern)
-import System.FilePath qualified as FP
 import Unsafe.Coerce (unsafeCoerce)
+
+import Achille.Core.Recipe
+import Achille.Core.Program
+import Achille.Diffable as Diffable
+import Achille.DynDeps (DynDeps)
+import Achille.Path
+import Achille.Task.Prim
+import Achille.IO
 
 import Prelude            qualified
 import Data.IntMap.Strict qualified as IntMap
 import Data.IntSet        qualified as IntSet
 import Data.Map.Strict    qualified as Map
-
-import Achille.Cache
-import Achille.Context (Context)
-import Achille.Diffable as Diffable
-import Achille.DynDeps (DynDeps)
-import Achille.Path
-import Achille.Result
-import Achille.IO
-
-import Achille.Core.Recipe
-import Achille.Core.Program
-
-import Achille.Context qualified as Ctx
+import System.FilePath    qualified as FP
+import Achille.Context    qualified as Ctx
 
 
 -- NOTE(flupe): maybe we should *NOT* make all the applications strict.
@@ -90,8 +82,8 @@ instance {-# OVERLAPPING #-} Monad m => IsString (Task m Path) where
       rec = recipe "Achille.Core.Task.toPath" \_ -> do
         curr <- reader Ctx.currentDir
         let path :: Path = normalise (curr </> fromString p)
-        same <- (Just path ==) . fromCache <$> getCache
-        putCache (toCache path)
+        same <- (Just path ==) <$> fromCache
+        toCache path
         pure (value (not same) path)
 
 -- instance {-# OVERLAPPING #-} Applicative m => IsString (Task m Pattern) where

--- a/achille/Achille/IO.hs
+++ b/achille/Achille/IO.hs
@@ -39,6 +39,8 @@ class AchilleIO m where
     readCommand :: String -> [String] -> m String
     -- | Log a string to stdout.
     log :: String -> m ()
+    -- | Log a /debug/ string to stdout.
+    debug :: String -> m ()
 
     -- | Find all paths matching a given globpattern, relative to a given directory.
     --   All paths returned must be relative to the current working directory.
@@ -65,5 +67,6 @@ instance AchilleIO IO where
     callCommand          = Process.callCommand
     readCommand cmd args = Process.readProcess cmd args []
     log                  = Prelude.putStrLn
+    debug                = Prelude.putStrLn
     glob dir pattern     = map fromString <$> Glob.globDir1 pattern (toFilePath dir)
     getModificationTime  = Directory.getModificationTime . toFilePath

--- a/achille/Achille/Recipe.hs
+++ b/achille/Achille/Recipe.hs
@@ -58,6 +58,7 @@ readByteString = recipe "readText" \v -> do
   path     <- (</>) <$> contentDir <*> pure (theVal v)
   lastTime <- lastTime
   time <- getModificationTime path
+  AIO.debug ("Reading " <> show path)
   text <- readFile path
   pure (value (time > lastTime || hasChanged v) text)
 
@@ -67,6 +68,7 @@ readText = recipe "readText" \v -> do
   path     <- (</>) <$> contentDir <*> pure (theVal v)
   lastTime <- lastTime
   time <- getModificationTime path
+  AIO.debug ("Reading " <> show path)
   text <- decodeUtf8 <$> readFile path
   pure (value (time > lastTime || hasChanged v) text)
 

--- a/achille/Achille/Recipe.hs
+++ b/achille/Achille/Recipe.hs
@@ -28,6 +28,7 @@ import Data.Bifunctor (bimap, first)
 import Data.ByteString (ByteString)
 import Data.List qualified as List (sortOn)
 import Data.Map.Strict (Map)
+import Data.Maybe (isNothing)
 import Data.Set (Set)
 import Data.Text (Text, unpack, pack)
 import Data.Text.Encoding (decodeUtf8)
@@ -44,7 +45,7 @@ import Achille.Core.Recipe
 import Achille.Context (Context)
 import Achille.DynDeps
 import Achille.Path
-import Achille.Result (Result)
+import Achille.Result
 import Achille.Writable (Writable)
 
 import Achille.Writable qualified as Writable
@@ -56,37 +57,37 @@ import Achille.Config qualified as Cfg
 
 -- | Read a bytestring from file.
 readByteString :: (Monad m, AchilleIO m) => Recipe m Path ByteString
-readByteString = recipe "readText" \cache v -> do
+readByteString = recipe "readText" \v -> do
   path     <- (</>) <$> Res.contentDir <*> pure (theVal v)
   lastTime <- Res.lastTime
   time <- getModificationTime path
   text <- AIO.readFile path
-  pure (value (time > lastTime || hasChanged v) text, cache)
+  pure (value (time > lastTime || hasChanged v) text)
 
 -- | Read text from file.
 readText :: (Monad m, AchilleIO m) => Recipe m Path Text
-readText = recipe "readText" \cache v -> do
+readText = recipe "readText" \v -> do
   path     <- (</>) <$> Res.contentDir <*> pure (theVal v)
   lastTime <- Res.lastTime
   time <- AIO.getModificationTime path
   text <- decodeUtf8 <$> AIO.readFile path
-  pure (value (time > lastTime || hasChanged v) text, cache)
+  pure (value (time > lastTime || hasChanged v) text)
 
 -- | Print a message to stdout.
 debug :: (Monad m, AchilleIO m) => Recipe m Text ()
-debug = recipe "debug" \cache v -> AIO.log (unpack $ theVal v) $> (unit, cache)
+debug = recipe "debug" \v -> AIO.log (unpack $ theVal v) $> unit
 
 -- | Convert a path to a proper absolute URL, including the site prefix.
 toURL :: Monad m => Recipe m Path Text
-toURL = recipe "Achille.Recipe.toURL" \cache v -> do
+toURL = recipe "Achille.Recipe.toURL" \v -> do
   sitePrefix <- reader (Cfg.sitePrefix . Ctx.siteConfig)
-  pure (value (hasChanged v) ("/" <> sitePrefix <> pack (toFilePath (theVal v))), cache)
+  pure $ value (hasChanged v) ("/" <> sitePrefix <> pack (toFilePath (theVal v)))
 
 -- | Write something to file, /iff/ this thing has changed since the last run.
 write
   :: (Monad m, AchilleIO m, Writable m a)
   => Recipe m (Path, a) Text
-write = toURL <<< recipe "write" \cache v -> do
+write = toURL <<< recipe "write" \v -> do
   let (vsrc, vx) = splitValue v
   path       <- (</>) <$> Res.outputDir <*> pure (theVal vsrc)
   cleanBuild <- reader Ctx.cleanBuild
@@ -94,11 +95,11 @@ write = toURL <<< recipe "write" \cache v -> do
   when (cleanBuild || hasChanged v)
     $  AIO.log ("Writing " <> show path)
     *> (lift $ Writable.write path (theVal vx))
-  pure (vsrc, cache)
+  pure vsrc
 
 -- | Copies a file to the output path, preserving its name.
 copy :: (Monad m, AchilleIO m) => Recipe m Path Text
-copy = toURL <<< recipe "copy" \cache vsrc -> do
+copy = toURL <<< recipe "copy" \vsrc -> do
   ipath <- (</>) <$> Res.contentDir <*> pure (theVal vsrc)
   opath <- (</>) <$> Res.outputDir  <*> pure (theVal vsrc)
   lastTime <- Res.lastTime
@@ -109,48 +110,49 @@ copy = toURL <<< recipe "copy" \cache vsrc -> do
   when (cleanBuild || hasChanged vsrc || time > lastTime) $
     AIO.log ("Copying " <> show ipath) *> AIO.copyFile ipath opath
   tell $ dependsOnFile ipath
-  pure (vsrc, cache)
+  pure vsrc
 
 -- | Map a function over a list.
-map :: Applicative m => (a -> b) -> Recipe m [a] [b]
-map f = recipe "map" \cache v -> pure . (, cache) $
+map :: Monad m => (a -> b) -> Recipe m [a] [b]
+map f = recipe "map" \v -> pure
   case v of
     Value xs c Nothing   -> value c (Prelude.map f xs)
     Value xs c (Just vs) -> Value (Prelude.map f xs) c (Just (fmap f <$> vs))
 
 -- | Reverse a list.
-reverse :: Applicative m => Recipe m [a] [a]
-reverse = recipe "reverse" \cache v -> pure (joinValue (Prelude.reverse (splitValue v)), cache)
+reverse :: Monad m => Recipe m [a] [a]
+reverse = recipe "reverse" \v -> pure (joinValue (Prelude.reverse (splitValue v)))
 
 -- TODO(flupe): change information is incorrect here. if a value changes position, then it is "new" in some sense.
 --              maybe we really need difflists
 
 -- | Sort a list using the prelude @sort@.
 --   Crucially this takes care of tracking change information in the list.
-sort :: (Applicative m, Ord a) => Recipe m [a] [a]
-sort = recipe "sort" \cache v -> pure (joinValue (List.sortOn theVal (splitValue v)), cache)
+sort :: (Monad m, Ord a) => Recipe m [a] [a]
+sort = recipe "sort" \v -> pure (joinValue (List.sortOn theVal (splitValue v)))
 
 -- | Sort a list using the prelude @sort@.
 --   Crucially this takes care of tracking change information in the list.
-sortOn :: (Applicative m, Ord b) => (a -> b) -> Recipe m [a] [a]
-sortOn f = recipe "sortOn" \cache v -> pure (joinValue (List.sortOn (f . theVal) (splitValue v)), cache)
+sortOn :: (Monad m, Ord b) => (a -> b) -> Recipe m [a] [a]
+sortOn f = recipe "sortOn" \v -> pure (joinValue (List.sortOn (f . theVal) (splitValue v)))
 
 -- TODO(flupe): make Int argument a task
 -- NOTE: not optimal, take/drop both lists?
 -- | Return the prefix of length @n@ of the input list.
-take :: (Applicative m) => Int -> Recipe m [a] [a]
-take n = recipe "take" \cache v -> pure (joinValue (Prelude.take n (splitValue v)), cache)
+take :: Monad m => Int -> Recipe m [a] [a]
+take n = recipe "take" \v -> pure (joinValue (Prelude.take n (splitValue v)))
 
 -- | Drop the first @n@ elements of the input list.
-drop :: Applicative m => Int -> Recipe m [a] [a]
-drop n = recipe "drop" \cache v -> pure (joinValue (Prelude.drop n (splitValue v)), cache)
+drop :: Monad m => Int -> Recipe m [a] [a]
+drop n = recipe "drop" \v -> pure (joinValue (Prelude.drop n (splitValue v)))
 
 -----------
 
-(!) :: (Applicative m, Ord k) => Recipe m (Map k v, k) v
-(!) = recipe "(!)" \cache v -> do
+(!) :: (Monad m, Ord k, AchilleIO m) => Recipe m (Map k v, k) v
+(!) = recipe "(!)" \v -> do
   let (vm, vk) = splitValue v
   let vs = splitValue vm
-  let vv = if hasChanged vk then value True (theVal vm Map.! theVal vk)
-                              else vs Map.! theVal vk
-  pure (vv, cache)
+  let vv = if hasChanged vk then value True <$> (theVal vm Map.!? theVal vk)
+                            else vs Map.!? theVal vk
+  when (isNothing vv) $ fail "oops"
+  forward vv

--- a/achille/Achille/Result.hs
+++ b/achille/Achille/Result.hs
@@ -1,27 +1,31 @@
 {-# LANGUAGE DerivingStrategies #-}
-module Achille.Result
-  ( Result
-  , runResult
-  , setDeps
-  , getContext
-  , getConfig
-  , lift
-  , contentDir
-  , outputDir
-  , updatedFiles
-  , lastTime
-  ) where
+module Achille.Result where
+--  ( Result
+--  , runResult
+--  , setDeps
+--  , getContext
+--  , getConfig
+--  , lift
+--  , contentDir
+--  , outputDir
+--  , updatedFiles
+--  , lastTime
+--  ) where
 
 import Data.Map.Strict (Map)
+import Data.Function ((&))
+import Data.Functor.Compose
 import Data.Time (UTCTime)
+import Control.Applicative (liftA2)
 import Control.Monad.Trans (MonadTrans, lift)
-import Control.Monad.Reader.Class  (MonadReader, reader, ask, asks)
-import Control.Monad.Writer.Class  (MonadWriter, writer, tell)
-import Control.Monad.Writer.Strict (WriterT, runWriterT)
-import Control.Monad.Trans.Reader  (ReaderT, runReaderT)
+import Control.Monad.RWS.Strict
+import Control.Monad.Reader.Class
+import Control.Monad.Writer.Class
+import Control.Monad.State.Class
 
 import Data.Map.Strict qualified as Map
 
+import Achille.Cache
 import Achille.Config (Config)
 import Achille.Context (Context)
 import Achille.DynDeps (DynDeps, dependsOnFile, dependsOnPattern)
@@ -32,24 +36,56 @@ import Achille.Config qualified as Cfg
 import Achille.Context qualified as Ctx
 
 
--- NOTE(flupe): Result is not a good name, as it actually represents an effectful computation in context.
+-- PrimTask m a ≃ Context -> Cache -> m (Maybe a, DynDeps, Cache)
+newtype PrimTask m a = PrimTask
+  { unPrimTask :: Compose (RWST Context DynDeps Cache m) Maybe a
+  } deriving newtype (Functor, Applicative)
 
-newtype Result m a = Result (ReaderT Context (WriterT DynDeps m) a)
-  deriving newtype (Functor, Applicative, Monad)
-  deriving newtype (MonadReader Context, MonadWriter DynDeps)
-  -- TODO(flupe): MonadReader Config Result
+instance Monad m => Monad (PrimTask m) where
+  PrimTask (Compose x) >>= f =
+    PrimTask $ Compose $ x >>= \case
+      Nothing -> pure Nothing
+      Just x  -> getCompose (unPrimTask (f x))
 
-runResult :: Result m a -> Context -> m (a, DynDeps)
-runResult (Result r) = runWriterT . runReaderT r
+instance Monad m => MonadReader Context (PrimTask m) where
+  ask = PrimTask $ Compose $ Just <$> ask
+  local f (PrimTask (Compose x)) = PrimTask (Compose (local f x))
 
-instance MonadTrans Result where
-  {-# INLINE lift #-}
-  lift = Result . lift . lift
+instance Monad m => MonadWriter DynDeps (PrimTask m) where
+  writer (x, w) = PrimTask $ Compose $ writer (Just x, w)
+  tell deps = PrimTask (Compose (Just <$> tell deps))
+  listen (PrimTask (Compose x)) =
+    PrimTask $ Compose do
+      (y, deps) <- listen x
+      pure (liftA2 (,) y (pure deps))
+  pass (PrimTask (Compose x)) =
+    PrimTask $ Compose do
+      (y, deps) <- listen x
+      case y of
+        Nothing -> pure Nothing
+        Just (z, f) -> writer (Just z, f deps)
 
--- NOTE(flupe): maybe for AchilleIO (Result m) we actually want to do
---              smart path transformation?
+instance Monad m => MonadState Cache (PrimTask m) where
+  get = PrimTask $ Compose $ Just <$> get
+  put cache = PrimTask $ Compose $ Just <$> put cache
 
-instance (Monad m, AchilleIO m) => AchilleIO (Result m) where
+instance MonadTrans PrimTask where
+  lift = PrimTask . Compose . lift . fmap Just
+
+silentFail :: Monad m => PrimTask m a
+silentFail = PrimTask (Compose (pure Nothing))
+
+forward :: Monad m => Maybe a -> PrimTask m a
+forward Nothing = silentFail
+forward (Just x) = pure x
+
+instance (Monad m, AchilleIO m) => MonadFail (PrimTask m) where
+  fail s = lift (AIO.log s) *> PrimTask (Compose (pure Nothing))
+
+runPrimTask :: PrimTask m a -> Context -> Cache -> m (Maybe a, Cache, DynDeps)
+runPrimTask (PrimTask (Compose x)) = runRWST x
+
+instance (Monad m, AchilleIO m) => AchilleIO (PrimTask m) where
   getModificationTime path =
     reader ((Map.!? path) . Ctx.updatedFiles) >>= \case
       Just mtime -> pure mtime
@@ -68,28 +104,38 @@ instance (Monad m, AchilleIO m) => AchilleIO (Result m) where
   readCommand cmd args = lift (AIO.readCommand cmd args)
   glob root pat = lift (AIO.glob root pat) <* tell (dependsOnPattern pat)
 
+-- NOTE(flupe): ^ maybe for AchilleIO (PrimTask m) we actually want to do
+--                smart path transformation?
 
--- TODO(flupe): error recovery with non-failing fail
-instance MonadFail m => MonadFail (Result m) where fail = lift . fail
+withCache :: Monad m => Cache -> PrimTask m a -> PrimTask m (Maybe a, Cache)
+withCache lcache (PrimTask (Compose t)) = PrimTask $ Compose $ RWST \ctx cache -> do
+  (x, lcache, deps) <- runRWST t ctx lcache
+  pure (Just (x, lcache), cache, deps)
+
+getCache :: Monad m => PrimTask m Cache
+getCache = get
+
+putCache :: Monad m => Cache -> PrimTask m ()
+putCache = put
 
 -- Some context projections to avoid having to do it manually each time
-contentDir :: Monad m => Result m Path
+contentDir :: Monad m => PrimTask m Path
 contentDir = reader (Cfg.contentDir . Ctx.siteConfig)
 
-outputDir :: Monad m => Result m Path
+outputDir :: Monad m => PrimTask m Path
 outputDir = reader (Cfg.outputDir . Ctx.siteConfig)
 
-updatedFiles :: Monad m => Result m (Map Path UTCTime)
+updatedFiles :: Monad m => PrimTask m (Map Path UTCTime)
 updatedFiles = reader Ctx.updatedFiles
 
-lastTime :: Monad m => Result m UTCTime
+lastTime :: Monad m => PrimTask m UTCTime
 lastTime = reader Ctx.lastTime
 
-getContext :: Monad m => Result m Context
+getContext :: Monad m => PrimTask m Context
 getContext = ask
 
-getConfig :: Monad m => Result m Config
+getConfig :: Monad m => PrimTask m Config
 getConfig = asks Ctx.siteConfig
 
-setDeps :: Monad m => DynDeps -> Result m ()
+setDeps :: Monad m => DynDeps -> PrimTask m ()
 setDeps = tell

--- a/achille/Achille/Result.hs
+++ b/achille/Achille/Result.hs
@@ -1,16 +1,21 @@
 {-# LANGUAGE DerivingStrategies #-}
-module Achille.Result where
---  ( Result
---  , runResult
---  , setDeps
---  , getContext
---  , getConfig
---  , lift
---  , contentDir
---  , outputDir
---  , updatedFiles
---  , lastTime
---  ) where
+module Achille.Result
+  ( PrimTask
+  , runPrimTask
+  , setDeps
+  , getContext
+  , getConfig
+  , lift
+  , silentFail
+  , forward
+  , withCache
+  , getCache
+  , putCache
+  , contentDir
+  , outputDir
+  , updatedFiles
+  , lastTime
+  ) where
 
 import Data.Map.Strict (Map)
 import Data.Function ((&))

--- a/achille/Achille/Task.hs
+++ b/achille/Achille/Task.hs
@@ -86,7 +86,7 @@ copy
   => Task m Path -> Task m Text
 copy = apply Recipe.copy
 
-(-<.>) :: Applicative m => Task m Path -> Task m String -> Task m Path
+(-<.>) :: Monad m => Task m Path -> Task m String -> Task m Path
 path -<.> ext = liftA2 (Path.-<.>) path ext
 
 readText :: (AchilleIO m, Monad m) => Task m Path -> Task m Text
@@ -99,28 +99,28 @@ readText = apply Recipe.readText
 -- Each of them was implemented so that information change of input gets
 -- propagated and preserved.
 
-map :: Applicative m => (a -> b) -> Task m [a] -> Task m [b]
+map :: Monad m => (a -> b) -> Task m [a] -> Task m [b]
 map f = apply (Recipe.map f)
 
 -- | Sort a list using the prelude @sort@.
-reverse :: Applicative m => Task m [a] -> Task m [a]
+reverse :: Monad m => Task m [a] -> Task m [a]
 reverse = apply Recipe.reverse
 
 -- | Sort a list using the prelude @sort@.
-sort :: (Applicative m, Ord a) => Task m [a] -> Task m [a]
+sort :: (Monad m, Ord a) => Task m [a] -> Task m [a]
 sort = apply Recipe.sort
 
 -- | Sort a list using the prelude @sort@.
 -- Crucially this takes care of tracking change information in the list.
-sortOn :: (Applicative m, Ord b) => (a -> b) -> Task m [a] -> Task m [a]
+sortOn :: (Monad m, Ord b) => (a -> b) -> Task m [a] -> Task m [a]
 sortOn f = apply (Recipe.sortOn f)
 
 -- | Return the prefix of length @n@ of the input list.
-take :: (Applicative m) => Int -> Task m [a] -> Task m [a]
+take :: (Monad m) => Int -> Task m [a] -> Task m [a]
 take n = apply (Recipe.take n)
 
 -- | Drop the first @n@ elements of the input list.
-drop :: Applicative m => Int -> Task m [a] -> Task m [a]
+drop :: Monad m => Int -> Task m [a] -> Task m [a]
 drop n = apply (Recipe.drop n)
 
 
@@ -131,5 +131,5 @@ drop n = apply (Recipe.drop n)
 -- propagated and preserved.
 
 infixl 9 !
-(!) :: (Applicative m, Ord k) => Task m (Map k a) -> Task m k -> Task m a
+(!) :: (Monad m, Ord k, AchilleIO m) => Task m (Map k a) -> Task m k -> Task m a
 (!) m k = apply (Recipe.!) (m :*: k)

--- a/achille/Achille/Task.hs
+++ b/achille/Achille/Task.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE GADTs, RecordWildCards, ViewPatterns, PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns, OverloadedStrings, PatternSynonyms #-}
 
 module Achille.Task 
   ( module Achille.Core.Task
   , pattern (:*:)
   , toURL
+  , log
+  , debug
   , write
   , copy
   , (-<.>)
@@ -24,7 +26,7 @@ module Achille.Task
   ) where
 
 import Prelude
-  hiding (fst, snd, (>>), (>>=), fail, (.), reverse, take, drop, map)
+  hiding (log, fst, snd, (>>), (>>=), fail, (.), reverse, take, drop, map)
 import Control.Applicative (Applicative(liftA2))
 import Control.Category
 import Control.Arrow (arr)
@@ -75,6 +77,12 @@ split p = (fst p, snd p)
 
 toURL :: Monad m => Task m Path -> Task m Text
 toURL = apply Recipe.toURL
+
+log :: (AchilleIO m, Monad m) => Task m Text -> Task m ()
+log = apply Recipe.log
+
+debug :: (AchilleIO m, Monad m) => Task m Text -> Task m ()
+debug = apply Recipe.debug
 
 write
   :: (AchilleIO m, Monad m, Writable m a)

--- a/achille/Achille/Task/Prim.hs
+++ b/achille/Achille/Task/Prim.hs
@@ -64,7 +64,7 @@ forward Nothing = halt
 forward (Just x) = pure x
 
 instance (Monad m, AchilleIO m) => MonadFail (PrimTask m) where
-  fail s = lift (AIO.log s) *> halt
+  fail s = lift (AIO.debug s) *> halt
 
 runPrimTask :: PrimTask m a -> Context -> Cache -> m (Maybe a, Cache, DynDeps)
 runPrimTask (PrimTask x) = runRWST $ runMaybeT x
@@ -85,6 +85,7 @@ instance (Monad m, AchilleIO m) => AchilleIO (PrimTask m) where
   listDir = lift . AIO.listDir
   callCommand = lift . AIO.callCommand
   log = lift . AIO.log
+  debug = lift . AIO.debug
   readCommand cmd args = lift (AIO.readCommand cmd args)
   glob root pat = lift (AIO.glob root pat) <* tell (dependsOnPattern pat)
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,8 +16,9 @@ import Achille.Task
 
 import Test.Achille.FakeIO
 import Test.Achille.Common
-import Test.Achille.Match qualified as Match
+import Test.Achille.Match     qualified as Match
 import Test.Achille.ReadWrite qualified as ReadWrite
+import Test.Achille.Recovery  qualified as Recovery
 
 
 main :: IO ()
@@ -27,6 +28,7 @@ tests :: TestTree
 tests = testGroup "Tests"
   [ Match.tests
   , ReadWrite.tests
+  , Recovery.tests
   , testCase "copy" $
       exactRun baseFS baseCtx
         A.do copy "un.txt"

--- a/tests/Test/Achille/FakeIO.hs
+++ b/tests/Test/Achille/FakeIO.hs
@@ -2,11 +2,12 @@
 
 module Test.Achille.FakeIO where
 
-import Data.Bifunctor (bimap)
+import Data.Bifunctor (bimap, first)
 import Data.Functor ((<&>))
 import Data.Map.Strict (Map)
 import Data.Maybe
 import Data.Time.Clock (UTCTime(..))
+import Control.Monad (join)
 import Control.Monad.Fail (MonadFail, fail)
 import Control.Monad.Writer
 
@@ -144,6 +145,6 @@ exactRun :: (Show b, Eq b)
   -> (Maybe b, [Actions])
   -> Assertion
 exactRun fs ctx t =
-    let fakeIO = runTask t ctx emptyCache <&> \(v, x, y) -> theVal v
+    let fakeIO = runTask t ctx emptyCache <&> \(v, x, y) -> v
         trace = retrieveActions fakeIO fs
-    in (trace @?=)
+    in (first (fmap theVal . join) trace @?=)

--- a/tests/Test/Achille/FakeIO.hs
+++ b/tests/Test/Achille/FakeIO.hs
@@ -24,8 +24,8 @@ import Achille.Cache (Cache, emptyCache)
 import Achille.Diffable (Value(theVal))
 import Achille.Path
 import Achille.Context (Context)
-import Achille.Result
 import Achille.Task (Task, runTask)
+import Achille.Task.Prim
 import Achille.IO hiding ()
 
 -- | Poor man's glob. Inefficient, but that's not the point.

--- a/tests/Test/Achille/Recovery.hs
+++ b/tests/Test/Achille/Recovery.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE QualifiedDo, BlockArguments, OverloadedStrings #-}
+module Test.Achille.Recovery where
+
+import Prelude hiding (log, fail, (>>=))
+import Data.Text (Text)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Achille.Common
+import Test.Achille.FakeIO
+
+import Achille as A
+
+tests :: TestTree
+tests = testGroup "error recovery tests"
+
+  [ testCase "seq failure" $
+
+    -- the first task fails, yet the second one will succeed
+
+      exactRun baseFS baseCtx
+
+        A.do
+          fail "oops" >>= log
+          log "hello"
+
+        (Just (), [ Logged "hello" ])
+
+  , testCase "seq failure" $
+
+    -- and the ordering doesn't matter,
+    -- though if the last one fails we get no result
+
+      exactRun baseFS baseCtx
+
+        A.do
+          log "hello"
+          fail "oops" >>= log
+
+        (Nothing, [ Logged "hello" ])
+
+  , testCase "pair failure" $
+
+    -- Same thing for pairs
+    -- either subtask can fail and the other succeed
+
+      exactRun baseFS baseCtx
+
+        A.do (fail "oops" >>= log) :*: log "ok"
+
+        (Nothing, [ Logged "ok" ])
+  ]


### PR DESCRIPTION
Basic error recovery for independent tasks.

- [x] Testing
- [x] Moving `PrimTask` to its proper module.
- [x] Make failure propagate through program environment, so that tasks that don't depend on a variable associated with a failed computation may continue.
- [ ] ~~`MaybeT` seems to have quite an impact on performances.~~ 
  - Try to move to `MaybeContT` or something similar, then benchmark.
  - *Or*, one could use `throw`, `catch` and `unsafePerformIO`. Sounds fun, but dangerous.

Resolves #8.