### PR TITLE
List diff

### DIFF
--- a/achille.cabal
+++ b/achille.cabal
@@ -76,6 +76,8 @@ test-suite test
                , Test.Achille.Recovery
                , Test.Achille.Branching
                , Test.Achille.Caching
+               , Test.Achille.Misc
+               , Test.Achille.Glob
   build-depends: base                 >= 4.16    && < 4.18
                , binary               >= 0.8.9   && < 0.9
                , binary-instances     >= 1.0.3   && < 1.1

--- a/achille.cabal
+++ b/achille.cabal
@@ -23,6 +23,7 @@ source-repository head
 library
   default-language: GHC2021
   hs-source-dirs: achille
+  ghc-options: -Wextra
   default-extensions: BlockArguments
                     , ImportQualifiedPost
                     , LambdaCase

--- a/achille.cabal
+++ b/achille.cabal
@@ -74,6 +74,8 @@ test-suite test
                , Test.Achille.Match
                , Test.Achille.ReadWrite
                , Test.Achille.Recovery
+               , Test.Achille.Branching
+               , Test.Achille.Caching
   build-depends: base                 >= 4.16    && < 4.18
                , binary               >= 0.8.9   && < 0.9
                , binary-instances     >= 1.0.3   && < 1.1

--- a/achille/Achille/CLI.hs
+++ b/achille/Achille/CLI.hs
@@ -8,8 +8,6 @@ module Achille.CLI
   where
 
 import Control.Monad (forM, when)
-import Data.Binary (encode)
-import Data.Functor (void)
 import Data.List (nub)
 import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes)
@@ -22,12 +20,10 @@ import System.IO
 
 import Achille.Cache
 import Achille.Config (Config(..), defaultConfig, cacheFile)
-import Achille.Diffable (unit)
 import Achille.Dot (outputGraph)
 import Achille.Path
 import Achille.Task (Task, runTask)
-import Achille.Recipe hiding (void)
-import Achille.IO (AchilleIO(doesFileExist, readFileLazy, writeFileLazy))
+import Achille.IO (AchilleIO(doesFileExist))
 
 import Data.Binary          qualified as Binary
 import Data.ByteString.Lazy qualified as LBS
@@ -39,8 +35,6 @@ import Achille.Core.Task (toProgram)
 import Achille.Context (Context(..))
 import Achille.DynDeps
 import Achille.Task.Prim
-import Achille.Core.Recipe
-
 
 
 -- TODO(flupe): make the CLI interace extensible
@@ -163,5 +157,6 @@ instance Show Duration where
   show (Duration d) = stab (d * 10) ["ps", "ns", "μs", "ms", "s"]
     where
       stab :: Integer -> [String] -> String
-      stab x (unit:us@(_:_)) | x >= 10000 = stab (x `div` 1000) us
+      stab x (_   :us@(_:_)) | x >= 10000 = stab (x `div` 1000) us
       stab x (unit:_) = showFFloat (Just 1) (fromIntegral x / 10) (" " <> unit)
+      stab _ [] = ""

--- a/achille/Achille/Core/Program.hs
+++ b/achille/Achille/Core/Program.hs
@@ -1,46 +1,41 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE MultiWayIf #-}
 module Achille.Core.Program where
 
 import Prelude hiding ((.), id, seq, (>>=), (>>), fst, snd)
 
-import Control.Applicative (liftA2)
 import Control.Category
-import Control.Monad (forM)
 import Control.Monad.Reader.Class
 import Control.Monad.Writer.Class
 
+import GHC.Stack (HasCallStack)
 import Data.Binary (Binary)
-import Data.Functor ((<&>), ($>))
+import Data.Bifunctor (first, bimap)
+import Data.Functor ((<&>))
 import Data.IntMap.Strict (IntMap, (!?))
 import Data.IntSet (IntSet)
-import Data.List (sort)
 import Data.Map.Strict (Map)
-import Data.Maybe (fromMaybe, catMaybes, isNothing)
+import Data.List (uncons)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Monoid (All(..))
+import Data.String (fromString)
 import Data.Time (UTCTime)
 
-import System.FilePath.Glob (Pattern)
 import Unsafe.Coerce (unsafeCoerce)
 
 import Data.IntMap.Strict   qualified as IntMap
 import Data.IntSet          qualified as IntSet
-import Data.Set             qualified as Set
 import Data.Map.Strict      qualified as Map
-import System.FilePath      qualified as FP
-import System.FilePath.Glob qualified as Glob
 
-import Achille.Config (Config(..))
 import Achille.Context (Context(..))
 import Achille.Diffable
-import Achille.DynDeps (DynDeps, getFileDeps, dependsOnPattern)
+import Achille.DynDeps (DynDeps, getFileDeps)
 import Achille.IO (AchilleIO)
+import Achille.IO qualified as AIO
 import Achille.Path
 import Achille.Task.Prim
 import Achille.Core.Recipe
 
 import Achille.Cache qualified as Cache
-import Achille.IO    qualified as AIO
 
 
 -- | @Program m a@ is the internal representaion of tasks in achille.
@@ -55,16 +50,8 @@ data Program m a where
        -> Program m b
 
   -- Iteration
-  For :: (Binary a, Ord a, Eq b, Binary b)
-      => Program m [a] -> Program m b -> IntSet
+  For :: Program m [a] -> Program m b
       -> Program m [b]
-
-  -- -- File matching
-  -- Match  :: (Eq b, Binary b)
-  --        => !Pattern
-  --        -> Program m b -- ^ has a filepath in scope
-  --        -> IntSet
-  --        -> Program m [b]
 
   -- Conditional branching
   Ite :: Program m Bool -> Program m a -> Program m a -> Program m a
@@ -81,23 +68,26 @@ data Program m a where
   Pair :: Program m a -> Program m b -> Program m (a, b)
   Fail :: !String -> Program m a
 
+  -- | Executes a program in the current directory of the given path.
+  Scoped :: Program m Path -> Program m a -> Program m a
 
 instance Show (Program m a) where
   show p = case p of
-    Var k         -> "Var " <> show k
-    Seq x y       -> "Seq (" <> show x <> ") (" <> show y <> ")"
-    Bind x f      -> "Bind (" <> show x <> ") (" <> show f <> ")"
-    For xs f vs  -> "Match " <> show xs <> " (" <> show f <> ") (" <> show vs <> ")"
-    Ite c x y     -> "Ite (" <> show c <> ") (" <> show x <> ") (" <> show y <> ")"
-    Cached _ p    -> "Cached _ (" <> show p <> show ")"
-    Apply r x     ->  "Apply (" <> show r <> ") (" <> show x <> ")"
-    Pair x y      -> "Pair (" <> show x <> ") (" <> show y <> ")"
-    Fail s        -> "Fail " <> show s
-    Val _         -> "Val"
+    Var k        -> "Var " <> show k
+    Seq x y      -> "Seq (" <> show x <> ") (" <> show y <> ")"
+    Bind x f     -> "Bind (" <> show x <> ") (" <> show f <> ")"
+    For xs f     -> "For " <> show xs <> " (" <> show f <> ")"
+    Ite c x y    -> "Ite (" <> show c <> ") (" <> show x <> ") (" <> show y <> ")"
+    Cached _ p   -> "Cached _ (" <> show p <> show ")"
+    Apply r x    ->  "Apply (" <> show r <> ") (" <> show x <> ")"
+    Pair x y     -> "Pair (" <> show x <> ") (" <> show y <> ")"
+    Fail s       -> "Fail " <> show s
+    Val _        -> "Val"
+    Scoped p x   -> "Scoped (" <> show p <> ") (" <> show x <> ")"
 
 -- | Run a program given some context and incoming cache.
 runProgram
-  :: (Monad m, MonadFail m, AchilleIO m)
+  :: (Monad m, MonadFail m, AchilleIO m, HasCallStack)
   => Program m a -> PrimTask m (Value a)
 runProgram = runProgramIn emptyEnv
 {-# INLINE runProgram #-}
@@ -110,7 +100,7 @@ data Env = Env (IntMap BoxedValue) {-# UNPACK #-} !Int
 emptyEnv :: Env
 emptyEnv = Env IntMap.empty 0
 
-lookupEnv :: Env -> Int -> Maybe a
+lookupEnv :: HasCallStack => Env -> Int -> Maybe a
 lookupEnv (Env env _) k = env !? k <&> \(Boxed v) -> unsafeCoerce v
 
 bindEnv :: Env -> Value a -> Env
@@ -119,8 +109,13 @@ bindEnv (Env env n) x = Env (IntMap.insert n (Boxed x) env) (n + 1)
 envChanged :: Env -> IntSet -> Bool
 envChanged (Env env _) = IntSet.foldr' op False
   -- NOTE(flupe): maybe we can early return once we reach True
+  -- TODO(flupe): we shouldn't ever fail looking up the env,
+  --              so we're not filtering enough variables...
   where op :: Int -> Bool -> Bool
-        op ((env IntMap.!) -> Boxed v) = (|| hasChanged v)
+        op k b =
+          case env IntMap.!? k of
+            Just (Boxed v) -> hasChanged v || b
+            Nothing        -> b
 
 depsClean :: Map Path UTCTime -> UTCTime -> DynDeps -> Bool
 depsClean edits lastT (getFileDeps -> fdeps) = getAll $ foldMap (All . isClean) fdeps
@@ -156,11 +151,12 @@ runProgramIn env t = case t of
     cached :: Maybe (a, DynDeps, Cache) <- fromCache
     let (deps, cache) :: (DynDeps, Cache) =
           case cached of
-            Just (_, d, c) -> (d, c)
+            Just (_, d, c) -> (d     , c               )
             _              -> (mempty, Cache.emptyCache)
-    if isNothing cached
-        || envChanged env vs
-        || not (depsClean updatedFiles lastTime deps) then do
+    if  isNothing cached
+     || envChanged env vs
+     || not (depsClean updatedFiles lastTime deps) then do
+      -- AIO.log (fromString $ show $ envChanged env vs)
       ((v, cache'), deps) <- listen $ withCache cache $ runProgramIn env p
       case v of
         Nothing -> forward v
@@ -210,75 +206,42 @@ runProgramIn env t = case t of
         joinCache cx' cr'
         forward b
 
-  For (xs :: Program m [a]) (f :: Program m b) vs -> do
-    (cxs, cys)  <- splitCache
+  For (xs :: Program m [a]) (f :: Program m b) -> do
+    (cxs, cfor)  <- splitCache
     (vxs, cxs') <- withCache cxs $ runProgramIn env xs
     case vxs of
-      -- failure of getting input
-      Nothing -> joinCache cxs' cys *> halt
+      Nothing -> joinCache cxs' cfor *> halt
       Just (splitValue -> cxs) -> do
-        chunks :: Map a (b, DynDeps, Cache) <- fromMaybe Map.empty <$> fromCache
-        rezz :: [(ListChange b, Maybe (a, (b, DynDeps, Cache)))] <- forM cxs \case
-          Deleted k -> let (x, _, _) = chunks Map.! k in pure (Deleted x, Nothing) -- in the case were deleted info is given, it should already be in the cache
-          Inserted k -> do
-            ((v, cache), deps) <- listen $ withCache Cache.emptyCache $ runProgramIn env f
-            tell deps
-            case v of
-              Nothing -> halt
-              Just v  -> pure (Inserted (theVal v), Just (k, (theVal v, deps, cache)))
-          Kept vk ->
-            case chunks Map.!? theVal vk of
-              Just (cachedVal, deps, cache) -> undefined
-              Nothing -> undefined
-        let (changes, catMaybes -> items) = unzip rezz
-        toCache (Map.fromAscList items) -- unnecessary conversion??
-        pure (joinValue changes)
+        let chunks :: [Cache] = fromMaybe [] $ Cache.fromCache cfor
+        (ys, chunks') <- forChanges cxs chunks
+        joinCache cxs' (Cache.toCache chunks')
+        forward (joinValue <$> ys)
+    where
+      forChanges :: [ListChange a] -> [Cache] -> PrimTask m (Maybe [ListChange b], [Cache])
+      forChanges []           _     = pure (Just [], [])
+      forChanges (Deleted   :vs) cs = forChanges vs (drop 1 cs) <&> first (fmap (Deleted:))
+      forChanges (Inserted x:vs) cs = do
+        let env' = bindEnv env (value False x)
+        (y, cy) <- withCache Cache.emptyCache $ runProgramIn env' f
+        case y of
+          Nothing -> pure (Nothing, cy : cs)
+          Just vy -> forChanges vs cs <&> bimap (fmap (Inserted (theVal vy):)) (cy:)
+      forChanges (Kept v:vs) cs = do
+        let env' = bindEnv env v
+        let (cv, cs') = fromMaybe (Cache.emptyCache, []) (uncons cs)
+        (y, cy) <- withCache cv $ runProgramIn env' f
+        case y of
+          Nothing -> pure (Nothing, [cy])
+          Just vy -> forChanges vs cs' <&> bimap (fmap (Kept vy:)) (cy:)
 
-  -- Match pat (t :: Program m b) vars -> do
-  --   context@Context{..} :: Context <- ask
-  --   undefined
-    -- let Config{..} = siteConfig
-    -- let thepat = toFilePath currentDir FP.</> Glob.decompile pat
-    -- let pat' = Glob.simplify $ Glob.compile thepat -- NOTE(flupe): Glob.simplify doesn't do anything?
-    -- stored :: Map Path Cache <- fromMaybe Map.empty <$> fromCache
-
-    -- -- TODO: make this cleaner
-    -- current_paths <- Set.fromList . sort . fmap (normalise . makeRelative contentDir)
-    --           <$> AIO.glob contentDir pat'
-    -- let old_paths = Map.keysSet stored
-    --     all_paths = Set.union current_paths old_paths
-
-    -- -- invariant: A cache is returned iff the listchange is Inserted or Kept
-    -- res :: [(Maybe (ListChange b), Maybe Cache)]
-    --   <- Set.toList <$> forM all_paths \src -> do
-    --     mtime <- AIO.getModificationTime (contentDir </> src)
-    --     let currentDir = takeDirectory src
-    --     let fileCache = stored Map.!? src
-    --     case liftA2 (,) fileCache (Cache.fromCache =<< fileCache) :: Maybe (Cache, (b, DynDeps, Cache)) of
-    --       Just (cache, (x, deps, _))
-    --         | mtime <= lastTime
-    --         , not (envChanged env vars)
-    --         , depsClean updatedFiles lastTime deps ->
-    --             tell deps $> undefined -- (Just (value False x), cache)
-    --       mpast -> do
-    --         let (oldVal, cache) = case mpast of
-    --               Just (_, (x, _, cache)) -> (Just x, cache)
-    --               Nothing                 -> (Nothing, Cache.emptyCache)
-    --             env' = bindEnv env (value False src)
-    --         ((t, cache'), deps) <- listen $
-    --           local (\c -> c { currentDir = currentDir
-    --                          , updatedFiles = Map.insert (contentDir </> src) mtime updatedFiles
-    --                          })
-    --             $ withCache cache $ runProgramIn env' t
-    --         case t of
-    --           Nothing -> undefined -- pure (Nothing, Cache.emptyCache)
-    --           Just t  -> undefined -- pure (Just t, Cache.toCache (theVal t, deps, cache'))
-    --         -- pure ( value (Just (theVal t) == oldVal) (theVal t)
-    --         --      , toCache (theVal t, deps, cache')
-    --         --      )
-    -- tell (dependsOnPattern pat')
-    -- let (values, caches) = unzip res
-    -- toCache (Map.fromAscList (zip paths caches))
-    -- pure (joinValue (catMaybes values))
-
+  Scoped x y -> do
+    (cx, cy) <- splitCache
+    (msrc, cx') <- withCache cx $ runProgramIn env x
+    case msrc of
+      Nothing  -> joinCache cx' cy *> halt
+      Just (theVal -> src) -> do
+        (b, cy') <- withCache cy $ local (\c -> c {currentDir = takeDirectory src})
+                                 $ runProgramIn env y
+        joinCache cx' cy'
+        forward b
 {-# INLINE runProgramIn #-}

--- a/achille/Achille/Core/Recipe.hs
+++ b/achille/Achille/Core/Recipe.hs
@@ -5,21 +5,9 @@ import Prelude hiding ((.), id, seq, fail)
 
 import Control.Category
 import Control.Arrow
-import Data.Binary (Binary(..))
-import Data.List (nub)
 import Data.Text (Text)
-import Data.Time (UTCTime)
-import Data.Set (Set)
-import Data.Map.Strict (Map)
-import GHC.Generics (Generic)
-import System.FilePath.Glob (Pattern)
 
-import Data.Set qualified as Set
-import System.FilePath.Glob qualified as Glob
-
-import Achille.Path
 import Achille.Diffable
-import Achille.IO
 import Achille.Task.Prim
 
 
@@ -46,7 +34,7 @@ instance Show (Recipe m a b) where
   show Exl = "Exl"
   show Exr = "Exr"
   show Void = "Void"
-  show (Embed e r) = "Embed " <> show e
+  show (Embed e _) = "Embed " <> show e
 
 
 -- TODO(flupe): clean this up?
@@ -88,7 +76,7 @@ runRecipe r x = case r of
   Exr  -> pure $ snd (splitValue x)
   Void -> pure unit
 
-  Embed n r -> r x
+  Embed _ r -> r x
 
 
 {-# INLINE runRecipe #-}

--- a/achille/Achille/Core/Task.hs
+++ b/achille/Achille/Core/Task.hs
@@ -12,6 +12,7 @@ module Achille.Core.Task
   , apply
   , val
   , void
+  , cached
   , toProgram
   , ifThenElse
   ) where
@@ -168,3 +169,9 @@ ifThenElse (T b) (T x) (T y) = T \n ->
       (y', vsy) = y $! n
   in (Ite b' x' y', vsb <> vsx <> vsy)
 {-# INLINE ifThenElse #-}
+
+cached :: (Monad m, Binary a) => Task m a -> Task m a
+cached (T x) = T \n ->
+  let (x', vs) = x $! n
+  in (Cached vs x', vs)
+{-# INLINE cached #-}

--- a/achille/Achille/Core/Task.hs
+++ b/achille/Achille/Core/Task.hs
@@ -13,24 +13,19 @@ module Achille.Core.Task
   , val
   , void
   , toProgram
+  , ifThenElse
   ) where
 
 import Prelude hiding ((.), id, seq, fail, (>>=), (>>), fst, snd)
 
 import Control.Category
 import Control.Monad.Reader.Class (reader)
-import Control.Applicative (Alternative, empty, liftA2)
+import Control.Applicative (liftA2)
 import Control.Arrow
 import Data.Binary (Binary)
-import Data.IntMap.Strict (IntMap, (!?))
 import Data.IntSet (IntSet)
-import Data.List (sort)
-import Data.Map.Strict (Map)
-import Data.Maybe (fromMaybe)
 import Data.String (IsString(fromString))
-import Data.Time (UTCTime)
 import System.FilePath.Glob (Pattern)
-import Unsafe.Coerce (unsafeCoerce)
 
 import Achille.Core.Recipe
 import Achille.Core.Program
@@ -41,10 +36,7 @@ import Achille.Task.Prim
 import Achille.IO
 
 import Prelude            qualified
-import Data.IntMap.Strict qualified as IntMap
 import Data.IntSet        qualified as IntSet
-import Data.Map.Strict    qualified as Map
-import System.FilePath    qualified as FP
 import Achille.Context    qualified as Ctx
 
 
@@ -167,3 +159,12 @@ apply !r (T x) = T \n ->
           app Id x = x
           app r x = Apply r x
 {-# INLINE apply #-}
+
+-- | Conditionally run tasks
+ifThenElse :: Monad m => Task m Bool -> Task m a -> Task m a -> Task m a
+ifThenElse (T b) (T x) (T y) = T \n ->
+  let (b', vsb) = b $! n
+      (x', vsx) = x $! n
+      (y', vsy) = y $! n
+  in (Ite b' x' y', vsb <> vsx <> vsy)
+{-# INLINE ifThenElse #-}

--- a/achille/Achille/Diffable.hs
+++ b/achille/Achille/Diffable.hs
@@ -5,11 +5,12 @@ module Achille.Diffable
   , unit
   , Diffable(..)
 
-  , ListChange
+  , ListChange(..)
   , takeChanges
   , sortChangesOn
   , dropChanges
   , listChangeVal
+  , cmpChangesAsc
   ) where
 
 import Data.Foldable (Foldable(..), foldMap)
@@ -104,6 +105,16 @@ takeChanges n (c:cs) =
              Deleted _ -> n
              _         -> n - 1
   in c : takeChanges n' cs
+
+cmpChangesAsc :: (Ord a) => [a] -> [a] -> [ListChange a]
+cmpChangesAsc [] [] = []
+cmpChangesAsc xs [] = map Deleted xs
+cmpChangesAsc [] ys = map Inserted ys
+cmpChangesAsc (x:xs) (y:ys) =
+  case compare x y of
+    EQ -> Kept (value False x) : cmpChangesAsc xs ys
+    LT -> Deleted x  : cmpChangesAsc xs (y:ys)
+    GT -> Inserted y : cmpChangesAsc (x:xs) (y:ys)
 
 dropChanges :: Int -> [ListChange a] -> [ListChange a]
 dropChanges n cs | n <= 0 = cs

--- a/achille/Achille/Recipe.hs
+++ b/achille/Achille/Recipe.hs
@@ -121,7 +121,7 @@ map f = recipe "map" \v -> pure
 
 -- | Reverse a list.
 reverse :: Monad m => Recipe m [a] [a]
-reverse = recipe "reverse" \v -> pure (joinValue (Prelude.reverse (splitValue v)))
+reverse = recipe "reverse" (pure . joinValue . Prelude.reverse . splitValue)
 
 -- TODO(flupe): change information is incorrect here. if a value changes position, then it is "new" in some sense.
 --              maybe we really need difflists
@@ -129,22 +129,21 @@ reverse = recipe "reverse" \v -> pure (joinValue (Prelude.reverse (splitValue v)
 -- | Sort a list using the prelude @sort@.
 --   Crucially this takes care of tracking change information in the list.
 sort :: (Monad m, Ord a) => Recipe m [a] [a]
-sort = recipe "sort" \v -> pure (joinValue (List.sortOn theVal (splitValue v)))
+sort = sortOn id
 
 -- | Sort a list using the prelude @sort@.
 --   Crucially this takes care of tracking change information in the list.
 sortOn :: (Monad m, Ord b) => (a -> b) -> Recipe m [a] [a]
-sortOn f = recipe "sortOn" \v -> pure (joinValue (List.sortOn (f . theVal) (splitValue v)))
+sortOn f = recipe "sortOn" (pure . joinValue . sortChangesOn f . splitValue)
 
 -- TODO(flupe): make Int argument a task
--- NOTE: not optimal, take/drop both lists?
 -- | Return the prefix of length @n@ of the input list.
 take :: Monad m => Int -> Recipe m [a] [a]
-take n = recipe "take" \v -> pure (joinValue (Prelude.take n (splitValue v)))
+take n = recipe "take" (pure . joinValue . takeChanges n . splitValue)
 
 -- | Drop the first @n@ elements of the input list.
 drop :: Monad m => Int -> Recipe m [a] [a]
-drop n = recipe "drop" \v -> pure (joinValue (Prelude.drop n (splitValue v)))
+drop n = recipe "drop" (pure . joinValue . dropChanges n . splitValue)
 
 -----------
 

--- a/achille/Achille/Recipe.hs
+++ b/achille/Achille/Recipe.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, ApplicativeDo, RecordWildCards, OverloadedStrings #-}
+{-# LANGUAGE GADTs, ApplicativeDo, OverloadedStrings #-}
 module Achille.Recipe
   ( module Achille.Core.Recipe
   , log
@@ -20,23 +20,19 @@ module Achille.Recipe
 
 import Prelude hiding (reverse, take, drop, map, log, readFile)
 import Control.Monad (when)
-import Control.Monad.Trans (lift)
 import Control.Monad.Writer.Class
 import Control.Monad.Reader.Class
 import Control.Arrow
 import Data.Functor (($>))
-import Data.Bifunctor (bimap, first)
 import Data.ByteString (ByteString)
 import Data.Map.Strict (Map)
 import Data.Maybe (isNothing)
-import Data.Set (Set)
-import Data.Text (Text, unpack, pack)
+import Data.Text (Text, pack)
 import Data.Text.Encoding (decodeUtf8)
 
-import Achille.IO hiding (debug, log)
+import Achille.IO hiding (log)
 import Achille.Diffable
 import Achille.Core.Recipe ( Recipe, PrimRecipe , recipe, runRecipe)
-import Achille.Context (Context)
 import Achille.DynDeps
 import Achille.Path
 import Achille.Task.Prim

--- a/achille/Achille/Task.hs
+++ b/achille/Achille/Task.hs
@@ -10,6 +10,8 @@ module Achille.Task
   , copy
   , (-<.>)
   , readText
+  , glob
+  , match
   , -- * Operations over lists
     --
     -- $lists
@@ -29,6 +31,8 @@ import Prelude
   hiding (log, fst, snd, (>>), (>>=), fail, (.), reverse, take, drop, map)
 import Control.Applicative (Applicative(liftA2))
 import Data.Map.Strict (Map)
+import Data.Binary (Binary)
+import System.FilePath.Glob (Pattern)
 import Data.Text (Text)
 
 import Achille.IO (AchilleIO)
@@ -120,6 +124,14 @@ take n = apply (Recipe.take n)
 drop :: Monad m => Int -> Task m [a] -> Task m [a]
 drop n = apply (Recipe.drop n)
 
+-- | Return all paths matching the given pattern.
+glob :: (AchilleIO m, Monad m) => Task m Pattern -> Task m [Path]
+glob = apply Recipe.glob
+
+match
+  :: (Monad m, AchilleIO m, Binary b, Eq b)
+  => Task m Pattern -> (Task m Path -> Task m b) -> Task m [b]
+match p f = for (glob p) f
 
 -- $maps
 --

--- a/achille/Achille/Task.hs
+++ b/achille/Achille/Task.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE ViewPatterns, OverloadedStrings, PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns, PatternSynonyms #-}
 
-module Achille.Task 
+module Achille.Task
   ( module Achille.Core.Task
   , pattern (:*:)
   , toURL
@@ -28,24 +28,13 @@ module Achille.Task
 import Prelude
   hiding (log, fst, snd, (>>), (>>=), fail, (.), reverse, take, drop, map)
 import Control.Applicative (Applicative(liftA2))
-import Control.Category
-import Control.Arrow (arr)
-import Data.Binary (Binary)
 import Data.Map.Strict (Map)
-import Data.String (IsString(fromString))
 import Data.Text (Text)
-import System.FilePath.Glob (Pattern)
 
-import Achille.Diffable (Value, value)
 import Achille.IO (AchilleIO)
-import Achille.Recipe (Recipe)
 import Achille.Writable (Writable)
 
-import Prelude           qualified
-import Data.IntSet       qualified as IntSet
-import System.FilePath   qualified as FilePath
 import Achille.Recipe    qualified as Recipe
-import Achille.Writable  qualified as Writable
 
 import Achille.Core.Task
 import Achille.Path (Path)
@@ -141,3 +130,4 @@ drop n = apply (Recipe.drop n)
 infixl 9 !
 (!) :: (Monad m, Ord k, AchilleIO m) => Task m (Map k a) -> Task m k -> Task m a
 (!) m k = apply (Recipe.!) (m :*: k)
+

--- a/achille/Achille/Task/Prim.hs
+++ b/achille/Achille/Task/Prim.hs
@@ -27,16 +27,10 @@ module Achille.Task.Prim
 
 import Data.Binary (Binary)
 import Data.Map.Strict (Map)
-import Data.Function ((&))
 import Data.Text (Text)
 import Data.Time (UTCTime)
-import Control.Applicative (liftA2)
 import Control.Monad.RWS.Strict
-import Control.Monad.Reader.Class
-import Control.Monad.State.Class
-import Control.Monad.Trans (MonadTrans(lift))
 import Control.Monad.Trans.Maybe
-import Control.Monad.Writer.Class
 
 import Achille.Cache (Cache)
 import Achille.Config (Config)
@@ -53,8 +47,7 @@ import Achille.Context qualified as Ctx
 
 
 -- PrimTask m a ≃ Context -> Cache -> m (Maybe a, DynDeps, Cache)
-newtype PrimTask m a =
-  PrimTask { unPrimTask :: MaybeT (RWST Context DynDeps Cache m) a }
+newtype PrimTask m a = PrimTask (MaybeT (RWST Context DynDeps Cache m) a)
   deriving newtype (Functor, Applicative, Monad)
   deriving newtype (MonadReader Context, MonadState Cache, MonadWriter DynDeps)
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,7 +16,9 @@ import Achille.Task
 
 import Test.Achille.FakeIO
 import Test.Achille.Common
+import Test.Achille.Glob      qualified as Glob
 import Test.Achille.Match     qualified as Match
+import Test.Achille.Misc      qualified as Misc
 import Test.Achille.ReadWrite qualified as ReadWrite
 import Test.Achille.Recovery  qualified as Recovery
 import Test.Achille.Branching qualified as Branching
@@ -28,7 +30,9 @@ main = defaultMainWithIngredients [Reporter.ingredient] tests
 
 tests :: TestTree
 tests = testGroup "Tests"
-  [ Match.tests
+  [ Glob.tests
+  , Misc.tests
+  , Match.tests
   , ReadWrite.tests
   , Recovery.tests
   , Branching.tests

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,9 +16,10 @@ import Achille.Task
 
 import Test.Achille.FakeIO
 import Test.Achille.Common
-import Test.Achille.Match     qualified as Match
-import Test.Achille.ReadWrite qualified as ReadWrite
-import Test.Achille.Recovery  qualified as Recovery
+import Test.Achille.Match      qualified as Match
+import Test.Achille.ReadWrite  qualified as ReadWrite
+import Test.Achille.Recovery   qualified as Recovery
+import Test.Achille.Branching  qualified as Branching
 
 
 main :: IO ()
@@ -29,6 +30,7 @@ tests = testGroup "Tests"
   [ Match.tests
   , ReadWrite.tests
   , Recovery.tests
+  , Branching.tests
   , testCase "copy" $
       exactRun
         A.do copy "un.txt"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,10 +16,11 @@ import Achille.Task
 
 import Test.Achille.FakeIO
 import Test.Achille.Common
-import Test.Achille.Match      qualified as Match
-import Test.Achille.ReadWrite  qualified as ReadWrite
-import Test.Achille.Recovery   qualified as Recovery
-import Test.Achille.Branching  qualified as Branching
+import Test.Achille.Match     qualified as Match
+import Test.Achille.ReadWrite qualified as ReadWrite
+import Test.Achille.Recovery  qualified as Recovery
+import Test.Achille.Branching qualified as Branching
+import Test.Achille.Caching   qualified as Caching
 
 
 main :: IO ()
@@ -31,6 +32,7 @@ tests = testGroup "Tests"
   , ReadWrite.tests
   , Recovery.tests
   , Branching.tests
+  , Caching.tests
   , testCase "copy" $
       exactRun
         A.do copy "un.txt"

--- a/tests/Test/Achille/Branching.hs
+++ b/tests/Test/Achille/Branching.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE QualifiedDo, BlockArguments, OverloadedStrings, RebindableSyntax #-}
+module Test.Achille.Branching where
+
+import Prelude hiding (log, fail, (>>=))
+import Data.Text (Text)
+
+import Data.String
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Achille.Common
+import Test.Achille.FakeIO
+
+import Achille as A
+
+tests :: TestTree
+tests = testGroup "error recovery tests"
+
+  [ testCase "if true goes to the left" $ exactRun
+      A.do
+        if pure True then
+          log "left"
+        else
+          log "right"
+      (Just (), [ Logged "left" ])
+
+  , testCase "if false goes to the right" $ exactRun
+      A.do
+        if pure False then
+          log "left"
+        else
+          log "right"
+      (Just (), [ Logged "right" ])
+  ]

--- a/tests/Test/Achille/Branching.hs
+++ b/tests/Test/Achille/Branching.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE QualifiedDo, BlockArguments, OverloadedStrings, RebindableSyntax #-}
 module Test.Achille.Branching where
 
-import Prelude hiding (log, fail, (>>=))
+import Prelude hiding (log, fail, (>>=), (>>))
+import qualified Prelude ((>>), (>>=))
 import Data.Text (Text)
 
 import Data.String
@@ -13,7 +14,7 @@ import Test.Achille.FakeIO
 import Achille as A
 
 tests :: TestTree
-tests = testGroup "error recovery tests"
+tests = testGroup "conditional branching tests"
 
   [ testCase "if true goes to the left" $ exactRun
       A.do
@@ -30,4 +31,68 @@ tests = testGroup "error recovery tests"
         else
           log "right"
       (Just (), [ Logged "right" ])
+
+  , testCase "a branch is cached" $ testRun
+
+      A.do
+
+        if pure True then A.do
+          write "output.txt" (readText "fichier.txt")
+          pure ()
+        else log "nope"
+
+      Prelude.do
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            , WrittenFile "output/output.txt" "helloworld"
+            ]
+          )
+
+        waitASec
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            -- the input file is read again (for now) but nothing is written to disk,
+            -- because nothing has changed
+            ]
+          )
+
+  , testCase "branches have their own cache" $ testRun
+
+      A.do
+
+        if pure True then do
+          write "output.txt" (readText "fichier.txt")
+          pure ()
+        else do
+          write "output.txt" (readText "fichier.txt")
+          log "nope"
+
+      Prelude.do
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            , WrittenFile "output/output.txt" "helloworld"
+            ]
+          )
+
+        waitASec
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            -- the input file is read again (for now) but nothing is written to disk,
+            -- because nothing has changed
+            ]
+          )
   ]

--- a/tests/Test/Achille/Caching.hs
+++ b/tests/Test/Achille/Caching.hs
@@ -22,6 +22,7 @@ tests = testGroup "cached combinator"
   [ testCase "cached combinator does cache" $ testRun
 
       (cached A.do
+        log "hello"
         readText "fichier.txt"
           & write "output.txt"
         pure ())
@@ -30,7 +31,8 @@ tests = testGroup "cached combinator"
 
         buildAndExpect
           ( Just ()
-          , [ CheckedMTime "content/fichier.txt"
+          , [ Logged "hello"
+            , CheckedMTime "content/fichier.txt"
             , HasReadFile "content/fichier.txt"
             , WrittenFile "output/output.txt" "helloworld"
             ]
@@ -48,6 +50,7 @@ tests = testGroup "cached combinator"
   , testCase "cached combinator correct w.r.t dynamic dependencies" $ testRun
 
       (cached A.do
+        log "hello"
         readText "fichier.txt"
           & write "output.txt"
         pure ())
@@ -56,7 +59,8 @@ tests = testGroup "cached combinator"
 
         buildAndExpect
           ( Just ()
-          , [ CheckedMTime "content/fichier.txt"
+          , [ Logged "hello"
+            , CheckedMTime "content/fichier.txt"
             , HasReadFile "content/fichier.txt"
             , WrittenFile "output/output.txt" "helloworld"
             ]
@@ -72,6 +76,7 @@ tests = testGroup "cached combinator"
           ( Just ()
           , [ CheckedFile "content/fichier.txt"
             , CheckedMTime "content/fichier.txt"
+            , Logged "hello"
             , HasReadFile "content/fichier.txt"
             , WrittenFile "output/output.txt" "hello"
             ]
@@ -82,7 +87,7 @@ tests = testGroup "cached combinator"
       A.do
         x <- readText "fichier.txt"
         y <- readText "post.md"
-        cached $ write "output.txt" x
+        cached $ log "hello" *> write "output.txt" x
         pure ()
 
       Prelude.do
@@ -93,6 +98,7 @@ tests = testGroup "cached combinator"
             , HasReadFile "content/fichier.txt"
             , CheckedMTime "content/post.md"
             , HasReadFile "content/post.md"
+            , Logged "hello"
             , WrittenFile "output/output.txt" "helloworld"
             ]
           )
@@ -124,6 +130,7 @@ tests = testGroup "cached combinator"
             , CheckedMTime "content/post.md"
             , HasReadFile "content/fichier.txt"
             , HasReadFile "content/post.md"
+            , Logged "hello"
             , WrittenFile "output/output.txt" "hello"
             ]
           )

--- a/tests/Test/Achille/Caching.hs
+++ b/tests/Test/Achille/Caching.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE QualifiedDo, BlockArguments, OverloadedStrings, RebindableSyntax #-}
+module Test.Achille.Caching where
+
+import Prelude hiding (log, fail, (>>=), (>>))
+import qualified Prelude
+import Data.Text (Text)
+import Data.Function ((&))
+import Control.Monad.State (modify)
+import qualified Data.Map as Map
+
+import Data.String
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Achille.Common
+import Test.Achille.FakeIO
+
+import Achille as A
+
+tests :: TestTree
+tests = testGroup "cached combinator"
+
+  [ testCase "cached combinator does cache" $ testRun
+
+      (cached A.do
+        readText "fichier.txt"
+          & write "output.txt"
+        pure ())
+
+      Prelude.do
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            , WrittenFile "output/output.txt" "helloworld"
+            ]
+          )
+
+        waitASec
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            ]
+          )
+
+  , testCase "cached combinator correct w.r.t dynamic dependencies" $ testRun
+
+      (cached A.do
+        readText "fichier.txt"
+          & write "output.txt"
+        pure ())
+
+      Prelude.do
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            , WrittenFile "output/output.txt" "helloworld"
+            ]
+          )
+
+        waitASec
+
+        -- TODO(flupe): make a nicer testing API
+        modify \ s -> s { tFS = Map.insert "content/fichier.txt"
+          (File (tCurrentTime s) "hello") (tFS s) }
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            , WrittenFile "output/output.txt" "hello"
+            ]
+          )
+
+  , testCase "cached combinator correct w.r.t environment variables" $ testRun
+
+      A.do
+        x <- readText "fichier.txt"
+        y <- readText "post.md"
+        cached $ write "output.txt" x
+        pure ()
+
+      Prelude.do
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedMTime "content/fichier.txt"
+            , HasReadFile "content/fichier.txt"
+            , CheckedMTime "content/post.md"
+            , HasReadFile "content/post.md"
+            , WrittenFile "output/output.txt" "helloworld"
+            ]
+          )
+
+        waitASec
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            , CheckedFile "content/post.md"
+            , CheckedMTime "content/post.md"
+            , HasReadFile "content/fichier.txt"
+            , HasReadFile "content/post.md"
+            ]
+          )
+
+        waitASec
+
+        -- TODO(flupe): make a nicer testing API
+        modify \ s -> s { tFS = Map.insert "content/fichier.txt"
+          (File (tCurrentTime s) "hello") (tFS s) }
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            , CheckedFile "content/post.md"
+            , CheckedMTime "content/post.md"
+            , HasReadFile "content/fichier.txt"
+            , HasReadFile "content/post.md"
+            , WrittenFile "output/output.txt" "hello"
+            ]
+          )
+
+        waitASec
+
+        -- TODO(flupe): make a nicer testing API
+        modify \ s -> s { tFS = Map.insert "content/post.md"
+          (File (tCurrentTime s) "nope") (tFS s) }
+
+        buildAndExpect
+          ( Just ()
+          , [ CheckedFile "content/fichier.txt"
+            , CheckedMTime "content/fichier.txt"
+            , CheckedFile "content/post.md"
+            , CheckedMTime "content/post.md"
+            , HasReadFile "content/fichier.txt"
+            , HasReadFile "content/post.md"
+            ]
+          )
+  ]

--- a/tests/Test/Achille/FakeIO.hs
+++ b/tests/Test/Achille/FakeIO.hs
@@ -125,7 +125,7 @@ buildAndExpect (eval, eactions) = ReaderT \t -> StateT \TState{..} -> do
   theVal <$> res          @?= eval
   (preactions ++ actions) @?= eactions
 
-  print deps
+  -- print deps
   -- updated state
   pure ((), TState (Just cache) deps tFS tCurrentTime tCurrentTime)
 

--- a/tests/Test/Achille/Glob.hs
+++ b/tests/Test/Achille/Glob.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE BlockArguments, QualifiedDo, OverloadedStrings #-}
+module Test.Achille.Glob where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Achille.FakeIO
+import Test.Achille.Common
+
+import Achille as A
+
+tests :: TestTree
+tests = testGroup "glob tests"
+  [ testCase "basic glob" $ exactRun
+      A.do glob "*.md"
+      ( Just ["other-post.md", "post.md"]
+      , []
+      )
+  ]

--- a/tests/Test/Achille/Match.hs
+++ b/tests/Test/Achille/Match.hs
@@ -29,11 +29,9 @@ tests = testGroup "match tests"
           void $ match "*/index.md" \src ->
             void $ match "meta.md" copy
         ( Just ()
-        , [ CheckedMTime "content/dir1/index.md"
-          , CheckedMTime "content/dir1/meta.md"
+        , [ CheckedMTime "content/dir1/meta.md"
           , CopiedFile "content/dir1/meta.md" "output/dir1/meta.md"
 
-          , CheckedMTime "content/dir2/index.md"
           , CheckedMTime "content/dir2/meta.md"
           , CopiedFile "content/dir2/meta.md" "output/dir2/meta.md"
           ]

--- a/tests/Test/Achille/Misc.hs
+++ b/tests/Test/Achille/Misc.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE BlockArguments, QualifiedDo, OverloadedStrings, OverloadedLists #-}
+module Test.Achille.Misc where
+
+import Data.Text (Text)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Achille.FakeIO
+import Test.Achille.Common
+
+import Achille as A
+
+tests :: TestTree
+tests = testGroup "misc tests"
+  [ testCase "basic glob" $ exactRun
+      A.do glob "*.md"
+      ( Just ["other-post.md", "post.md"]
+      , []
+      )
+  , testCase "overloaded lists and basic for" $ exactRun
+      A.do
+        for ["one.txt", "two.txt"] \src ->
+          write src ("hello" :: Task FakeIO Text)
+
+      ( Just ["/one.txt", "/two.txt"]
+      , [ WrittenFile "output/one.txt" "hello"
+        , WrittenFile "output/two.txt" "hello"
+        ]
+      )
+  ]


### PR DESCRIPTION
Closes #6. `match` is now expressed in terms of `for`, `cached` and `scoped`. A bit unfortunate to have to put `Scoped` in core programs though, but the implementation is still way cleaner than before.