### PR TITLE
Added switch statement

### DIFF
--- a/achille.cabal
+++ b/achille.cabal
@@ -49,21 +49,22 @@ library
                , Achille.Core.Program
                , Achille.Core.Task
                , Achille.Dot
-  build-depends: base                 >= 4.16   && < 4.18
-               , binary               >= 0.8.9  && < 0.9
-               , binary-instances     >= 1.0.3  && < 1.1
-               , bytestring           >= 0.11.3 && < 0.12
-               , constraints          >= 0.13.4 && < 0.14
-               , containers           >= 0.6.5  && < 0.7
-               , directory            >= 1.3.6  && < 1.4
-               , filepath             >= 1.4.2  && < 1.5
-               , Glob                 >= 0.10.2 && < 0.11
+  build-depends: base                 >= 4.16    && < 4.18
+               , binary               >= 0.8.9   && < 0.9
+               , binary-instances     >= 1.0.3   && < 1.1
+               , bytestring           >= 0.11.3  && < 0.12
+               , constraints          >= 0.13.4  && < 0.14
+               , containers           >= 0.6.5   && < 0.7
+               , directory            >= 1.3.6   && < 1.4
+               , filepath             >= 1.4.2   && < 1.5
+               , generics-sop         >= 0.5.1.0 && < 0.6
+               , Glob                 >= 0.10.2  && < 0.11
                , mtl                  >= 2.2     && < 2.3
-               , optparse-applicative >= 0.17.0 && < 0.18
-               , process              >= 1.6.13 && < 1.7
-               , text                 >= 2.0    && < 2.1
-               , time                 >= 1.11.1 && < 1.12
-               , transformers         >= 0.5.6  && < 0.7
+               , optparse-applicative >= 0.17.0  && < 0.18
+               , process              >= 1.6.13  && < 1.7
+               , text                 >= 2.0     && < 2.1
+               , time                 >= 1.11.1  && < 1.12
+               , transformers         >= 0.5.6   && < 0.7
 
 test-suite test
   default-language: GHC2021
@@ -96,3 +97,4 @@ test-suite test
                , text                 >= 2.0     && < 2.1
                , time                 >= 1.11.1  && < 1.12
                , achille              >= 0.1    && < 0.2
+               , generics-sop         >= 0.5.1.0 && < 0.6

--- a/achille/Achille/Core/Program.hs
+++ b/achille/Achille/Core/Program.hs
@@ -90,8 +90,11 @@ instance Show (Program m a) where
     Pair x y     -> "Pair (" <> show x <> ") (" <> show y <> ")"
     Fail s       -> "Fail " <> show s
     Val _        -> "Val"
-    Switch x _    -> "Switch (" <> show x <> ") ..."
+    Switch x bs  -> "Switch (" <> show x <> ") " <> show bs
     Scoped p x   -> "Scoped (" <> show p <> ") (" <> show x <> ")"
+
+instance Generic a => Show (Branches m a b) where
+  show (Branches bs) = show (SOP.hcollapse bs)
 
 -- | Run a program given some context and incoming cache.
 runProgram

--- a/achille/Achille/Task.hs
+++ b/achille/Achille/Task.hs
@@ -33,7 +33,6 @@ import Control.Applicative (Applicative(liftA2))
 import Control.Arrow (arr)
 import Data.Map.Strict (Map)
 import Data.Binary (Binary)
-import System.FilePath.Glob (Pattern)
 import Data.Text (Text)
 
 import Achille.IO (AchilleIO)
@@ -45,6 +44,7 @@ import Achille.Core.Task
 import Achille.Path (Path)
 import Achille.Path qualified as Path
 import Data.List qualified as List
+import System.FilePath.Glob qualified as Glob (Pattern)
 
 import Data.Binary.Instances.Time ()
 
@@ -127,12 +127,12 @@ drop :: Monad m => Int -> Task m [a] -> Task m [a]
 drop n = apply (Recipe.drop n)
 
 -- | Return all paths matching the given pattern.
-glob :: (AchilleIO m, Monad m) => Task m Pattern -> Task m [Path]
+glob :: (AchilleIO m, Monad m) => Task m Glob.Pattern -> Task m [Path]
 glob = apply Recipe.glob
 
 match
   :: (Monad m, AchilleIO m, Binary b, Eq b)
-  => Task m Pattern -> (Task m Path -> Task m b) -> Task m [b]
+  => Task m Glob.Pattern -> (Task m Path -> Task m b) -> Task m [b]
 match p f = for (glob p) \src -> cached (scoped src (f src))
 
 -- $maps

--- a/tests/Test/Achille/Misc.hs
+++ b/tests/Test/Achille/Misc.hs
@@ -1,4 +1,10 @@
 {-# LANGUAGE BlockArguments, QualifiedDo, OverloadedStrings, OverloadedLists #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DataKinds #-}
 module Test.Achille.Misc where
 
 import Data.Text (Text)
@@ -6,8 +12,29 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Achille.FakeIO
 import Test.Achille.Common
+import GHC.Generics qualified as GHC
+import Generics.SOP
 
 import Achille as A
+import Achille.Diffable (Lifted(Lifted))
+import Achille.Task (Pattern(..))
+
+-- custom datatypes
+data MyEither a b = MyLeft a | MyRight b
+  deriving GHC.Generic
+  deriving Generic
+
+-- boilerplate that could be generated automatically
+
+type MyEither_ a b = Lifted (MyEither a b)
+
+pattern MyLeft_ :: Task m a -> Pattern m (MyEither a b)
+pattern MyLeft_  x <- Pattern (Z (x :* Nil))
+
+pattern MyRight_ :: Task m b -> Pattern m (MyEither a b)
+pattern MyRight_ y <- Pattern (S (Z (y :* Nil)))
+
+-----------------------------------------------------
 
 tests :: TestTree
 tests = testGroup "misc tests"
@@ -25,5 +52,25 @@ tests = testGroup "misc tests"
       , [ WrittenFile "output/one.txt" "hello"
         , WrittenFile "output/two.txt" "hello"
         ]
+      )
+
+  , testCase "basic switch left" $ exactRun
+      A.do
+        v :: Task FakeIO (MyEither_ Int Bool)
+          <- pure (Lifted (MyLeft 3))
+        switch v \case
+          MyLeft_  x -> x
+          MyRight_ y -> pure 5
+      ( Just 3 , [])
+
+  , testCase "basic switch right" $ exactRun
+      A.do
+        v :: Task FakeIO (MyEither_ Int Bool)
+          <- pure (Lifted (MyRight True))
+        switch v \case
+          MyLeft_  x -> x
+          MyRight_ y -> pure 5
+      ( Just 5
+      , []
       )
   ]


### PR DESCRIPTION
Closes #15.

PoC implementation of embedded pattern-matching on SOP-encoded datatypes.

Caveats & limitations:
- Pattern synonyms have to be defined manually (but could be derived "easily" with TemplateHaskell)
- Pattern matches using `switch` have to be exhaustive, or the build script will fail before being evaluated.
- `switch` only matches one layer deep which, considering we have to exhaustively generate all possible patterns to figure out branches, is a nice way to make sure we don't explode the search space.