### PR TITLE
Parallel

### DIFF
--- a/achille.cabal
+++ b/achille.cabal
@@ -50,6 +50,7 @@ library
                , Achille.Core.Task
                , Achille.Dot
   build-depends: base                 >= 4.16   && < 4.18
+               , async                >= 2.2.1  && < 2.3
                , binary               >= 0.8.9  && < 0.9
                , binary-instances     >= 1.0.3  && < 1.1
                , bytestring           >= 0.11.3 && < 0.12

--- a/achille.cabal
+++ b/achille.cabal
@@ -53,6 +53,7 @@ library
                , binary               >= 0.8.9  && < 0.9
                , binary-instances     >= 1.0.3  && < 1.1
                , bytestring           >= 0.11.3 && < 0.12
+               , clock                >= 0.8.3  && < 0.9
                , constraints          >= 0.13.4 && < 0.14
                , containers           >= 0.6.5  && < 0.7
                , directory            >= 1.3.6  && < 1.4

--- a/achille/Achille/Task/Prim.hs
+++ b/achille/Achille/Task/Prim.hs
@@ -85,9 +85,15 @@ instance (Monad m, AchilleIO m) => AchilleIO (PrimTask m) where
   log = lift . AIO.log
   readCommand cmd args = lift (AIO.readCommand cmd args)
   glob root pat = lift (AIO.glob root pat) <* tell (dependsOnPattern pat)
-
 -- NOTE(flupe): ^ maybe for AchilleIO (PrimTask m) we actually want to do
 --                smart path transformation?
+
+  newEmptyMVar = lift AIO.newEmptyMVar
+  readMVar     = lift . AIO.readMVar
+  putMVar v    = lift . AIO.putMVar v
+  fork         = error "shouldn't use fork inside stateful computation"
+
+
 
 data LogType
   = LogErr

--- a/docs/docs.cabal
+++ b/docs/docs.cabal
@@ -5,6 +5,7 @@ build-type:         Simple
 tested-with:        GHC == 9.4.4
 executable docs
   main-is: Main.hs
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
   default-language: GHC2021
   default-extensions: BlockArguments
                     , DeriveAnyClass

--- a/tests/Test/Achille/FakeIO.hs
+++ b/tests/Test/Achille/FakeIO.hs
@@ -13,6 +13,7 @@ import Control.Monad.Writer.Strict
 import Control.Monad.State.Strict
 import Control.Monad.Reader
 import Control.Monad.Trans (lift)
+import Control.Monad.IO.Class (liftIO)
 
 import Data.Text (Text)
 import Data.ByteString      qualified as BS
@@ -21,6 +22,7 @@ import System.Directory     qualified as Directory
 import System.FilePath      qualified as FilePath
 import System.FilePath.Glob qualified as Glob
 import Data.Map.Strict      qualified as Map
+import Control.Concurrent   qualified as Concurrent
 
 
 import Achille.CLI (processDeps)
@@ -71,6 +73,10 @@ instance AchilleIO FakeIO where
     glob r pat = asks (globFS r pat)
     getCurrentTime = undefined
 
+    newEmptyMVar = liftIO Concurrent.newEmptyMVar
+    putMVar v = liftIO . Concurrent.putMVar v
+    readMVar = liftIO . Concurrent.readMVar
+    fork m = m
 
 runFakeIO :: FakeIO a -> FileSystem -> IO (a, [IOActions])
 runFakeIO c fs = runWriterT (runReaderT c fs)


### PR DESCRIPTION
Change of strategy. Before we only parallelized match. Now we also parallelize `>>` and `>>=`. Variables bound do not pause evaluation of the following tasks. Rather, it is when we reach a `Var` constructor that we wait for it to be ready in the environment.